### PR TITLE
Add wait time in setup for MPU9250 boot - Fix #10 issue

### DIFF
--- a/EDTracker2_9250/EDTracker2_9250/EDTracker2_9250.ino
+++ b/EDTracker2_9250/EDTracker2_9250/EDTracker2_9250.ino
@@ -240,6 +240,7 @@ void setup() {
   cbi(PORTD, 1);
 
   // Initialize the MPU:
+  delay(500);  // Wait boot end of MPU9250 
   initialize_mpu();
   enable_mpu();
 


### PR DESCRIPTION
add a wait time, in the setup, to be sure that the MPU9250 can answer I2C bus after "cold" startup.