### PR TITLE
Fix URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ EDTracker 2 sketches are currently as follows :
 
 Once built, you will need the EDTracker GUI software to calibrate and monitor -
 this is available in binary form only at this stage, via
-http://http://www.edtracker.org.uk/index.php/downloads.
+http://www.edtracker.org.uk/index.php/downloads
 
 Tested/verified with Arduino IDE 1.8.5
 


### PR DESCRIPTION
Corrected a typo in the edtracker.org.uk URL.

_NB. That site's TLS cert has expired. Probably worth updating cPanel and installing the LetsEncrypt plugin._